### PR TITLE
Move diff-cover enforcement from build job to DiffCoverageCheck

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,8 +25,6 @@ variables:
       value: $(Build.SourceBranchName)
   - name: UNIT_TEST_FLAG
     value: 'ENABLE_TRANSLIB_WRITE=y'
-  - name: DIFF_COVER_THRESHOLD
-    value: 80
 
 resources:
   repositories:
@@ -166,11 +164,6 @@ stages:
       name: sonicso1ES-amd64
       vmImage: ubuntu-22.04
 
-    variables:
-      DIFF_COVER_CHECK_THRESHOLD: 80
-      DIFF_COVER_ENABLE: 'true'
-      DIFF_COVER_WORKING_DIRECTORY: $(System.DefaultWorkingDirectory)/sonic-gnmi
-
     container:
       image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
 
@@ -250,8 +243,16 @@ stages:
     dependsOn: [PureCIJob, build]
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     timeoutInMinutes: 10
+
     pool:
       vmImage: ubuntu-22.04
+
+    variables:
+      DIFF_COVER_ENABLE: 'true'
+      DIFF_COVER_CHECK_THRESHOLD: 80
+      DIFF_COVER_WORKING_DIRECTORY: $(System.DefaultWorkingDirectory)
+      DIFF_COVER_COVERAGE_FILES: '$(Pipeline.Workspace)/coverage-integration/coverage.xml $(Pipeline.Workspace)/coverage-pure/coverage-pure.xml'
+
     steps:
     - checkout: self
       clean: true
@@ -262,17 +263,6 @@ stages:
 
     - download: current
       artifact: coverage-integration
-
-    - bash: |
-        set -euo pipefail
-        pip3 install --quiet diff-cover
-        diff-cover \
-          $(Pipeline.Workspace)/coverage-integration/coverage.xml \
-          $(Pipeline.Workspace)/coverage-pure/coverage-pure.xml \
-          --compare-branch origin/$(BUILD_BRANCH) \
-          --src-roots . \
-          --fail-under $(DIFF_COVER_THRESHOLD)
-      displayName: 'Run diff-cover'
 
 - stage: BuildAmd64
   dependsOn: []


### PR DESCRIPTION
Remove DIFF_COVER_* variables from the build job so it can be renamed without breaking the wrapper's GitHub check name coupling. The DiffCoverageCheck job now sets DIFF_COVER_ENABLE and related variables, making it the sole hook point for the sonic-build-web coverage wrapper.

The native diff-cover --fail-under step is removed since the wrapper handles threshold enforcement via GitHub checks.

Also removes the now-unused global DIFF_COVER_THRESHOLD variable.